### PR TITLE
Customize calendar styles to theme twentySixteen

### DIFF
--- a/style.css
+++ b/style.css
@@ -3951,3 +3951,10 @@ p > video {
 		padding: 0;
 	}
 }
+
+/* XTEC ************ AFEGIT - Customize styles simple calendar */
+/* 2017.03.08 @xaviernietosanchez */
+.widget .simcal-week-day{
+	white-space: nowrap !important;
+}
+/* ************ FI */


### PR DESCRIPTION
Afegir personalització per la correcta visualització del simple calendar sota el theme twenty sixteen.

Per provar:

- Cal afegir un calendari com pàgina i com a widget.
- Comprovar que la seva visualització es correcta, en català, castellà i angles.